### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - [ $default-branch ]
+      - main
   push:
     branches:
-      - [ $default-branch ]
+      - main
 jobs:
   build-and-test:
     name: Build and test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - [ $default-branch ]
   push:
     branches:
-      - master
+      - [ $default-branch ]
 jobs:
   build-and-test:
     name: Build and test


### PR DESCRIPTION
I noticed this when my horribly un-linted code in #7 was passing CI :slightly_smiling_face: 

This repo uses `main` as it's default branch but the Github Actions config file assumes `master` is used, so CI isn't actually running at the moment. ~~Fixes it by using the `$default-branch` macro which determines the default branch dynamically.~~ Edit: this only works in workflow templates apparently. So this PR just changes `master` => `main`.