### PR TITLE
Configure Cesium to be used without an Ion Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,5 @@
 ## Building
 * Set the envornment variables in a `.env.development.local` file:
   * `VUE_APP_OAUTH_CLIENT_ID`: A new OAuth2 public client ID, from an instance of `RD-OpenGeo`.
-  * `VUE_APP_CESIUM_ACCESS_TOKEN`: A 
-    [Cesium ion access token](https://cesium.com/learn/cesiumjs-learn/cesiumjs-quickstart/#step-1-create-an-account-and-get-a-token).
 * `yarn`
 * `yarn serve`

--- a/src/components/organisms/CesiumViewer.vue
+++ b/src/components/organisms/CesiumViewer.vue
@@ -203,7 +203,7 @@ export default defineComponent({
         selectionIndicator: false,
       });
       // Remove the Terrain section of the baseLayerPicker
-      viewer.baseLayerPicker.viewModel.terrainProviderViewModels.removeAll()
+      cesiumViewer.value.baseLayerPicker.viewModel.terrainProviderViewModels.removeAll()
 
       cesiumViewer.value.forceResize();
       cesiumViewer.value.camera.flyTo({

--- a/src/components/organisms/CesiumViewer.vue
+++ b/src/components/organisms/CesiumViewer.vue
@@ -21,6 +21,7 @@ export default defineComponent({
       // Create ProviderViewModel based on different imagery sources
       // - these can be used without Cesium Ion
       var imageryViewModels = [];
+
       /* Stamen's website (http://maps.stamen.com) as of 2019-08-28 says that the
        * maps they host may be used free of charge.  For http access, use a url like
        * http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png */
@@ -191,10 +192,9 @@ export default defineComponent({
 
       // Initialize the viewer - this works without a token
       cesiumViewer.value = new Cesium.Viewer('cesiumContainer', {
-        imageryProvider: false,
+        // imageryProvider: false,
         imageryProviderViewModels: imageryViewModels,
         selectedImageryProviderViewModel: imageryViewModels[0],
-        mapProjection: new Cesium.WebMercatorProjection(),
         animation: false,
         timeline: false,
         infoBox: false,
@@ -232,7 +232,7 @@ export default defineComponent({
             polygon: {
               hierarchy: positionData,
               material: new Cesium.ColorMaterialProperty(
-                Cesium.Color.WHITE.withAlpha(0.7),
+                Cesium.Color.RED.withAlpha(0.7),
               ),
             },
           });
@@ -244,7 +244,7 @@ export default defineComponent({
         let floatingPoint: any;
         const handler = new Cesium.ScreenSpaceEventHandler(cesiumViewer.value.canvas);
         handler.setInputAction((event: { position: any }) => {
-          const earthPosition = cesiumViewer.value.scene.pickPosition(event.position);
+          const earthPosition = cesiumViewer.value.camera.pickEllipsoid(event.position);
           if (Cesium.defined(earthPosition)) {
             if (activeShapePoints.length === 0) {
               floatingPoint = createPoint(earthPosition);
@@ -259,7 +259,7 @@ export default defineComponent({
         }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
         handler.setInputAction((event: { endPosition: any }) => {
           if (Cesium.defined(floatingPoint)) {
-            const newPosition = cesiumViewer.value.scene.pickPosition(event.endPosition);
+            const newPosition = cesiumViewer.value.camera.pickEllipsoid(event.endPosition);
             if (Cesium.defined(newPosition)) {
               floatingPoint.position.setValue(newPosition);
               activeShapePoints.pop();

--- a/src/components/organisms/CesiumViewer.vue
+++ b/src/components/organisms/CesiumViewer.vue
@@ -20,174 +20,173 @@ export default defineComponent({
     onMounted(() => {
       // Create ProviderViewModel based on different imagery sources
       // - these can be used without Cesium Ion
-      var imageryViewModels = [];
+      const imageryViewModels = [];
 
       /* Stamen's website (http://maps.stamen.com) as of 2019-08-28 says that the
        * maps they host may be used free of charge.  For http access, use a url like
        * http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png */
-      let StamenAttribution = 'Map tiles by <a href="http://stamen.com">Stamen ' +
-        'Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">' +
-        'CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap' +
-        '</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.';
+      const StamenAttribution = 'Map tiles by <a href="http://stamen.com">Stamen '
+        + 'Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">'
+        + 'CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap'
+        + '</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.';
 
       /* Per Carto's website regarding basemap attribution: https://carto.com/help/working-with-data/attribution/#basemaps */
-      let CartoAttribution = 'Map tiles by <a href="https://carto.com">Carto</a>, under CC BY 3.0. Data by <a href="https://www.openstreetmap.org/">OpenStreetMap</a>, under ODbL.'
+      const CartoAttribution = 'Map tiles by <a href="https://carto.com">Carto</a>, under CC BY 3.0. Data by <a href="https://www.openstreetmap.org/">OpenStreetMap</a>, under ODbL.';
 
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'OpenStreetMap',
         iconUrl: Cesium.buildModuleUrl('Widgets/Images/ImageryProviders/openStreetMap.png'),
-        tooltip: 'OpenStreetMap (OSM) is a collaborative project to create a free editable \
-      map of the world.\nhttp://www.openstreetmap.org',
-        creationFunction: function() {
+        tooltip: 'OpenStreetMap (OSM) is a collaborative project to create a free editable map of the world.\nhttp://www.openstreetmap.org',
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
             subdomains: 'abc',
             minimumLevel: 0,
-            maximumLevel: 19
+            maximumLevel: 19,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Positron',
         tooltip: 'CartoDB Positron basemap',
         iconUrl: 'http://a.basemaps.cartocdn.com/light_all/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
             credit: CartoAttribution,
             minimumLevel: 0,
-            maximumLevel: 18
+            maximumLevel: 18,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Positron without labels',
         tooltip: 'CartoDB Positron without labels basemap',
         iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/light_nolabels/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://{s}.basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}.png',
             credit: CartoAttribution,
             minimumLevel: 0,
-            maximumLevel: 18
+            maximumLevel: 18,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Dark Matter',
         tooltip: 'CartoDB Dark Matter basemap',
         iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/dark_all/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://{s}.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png',
             credit: CartoAttribution,
             minimumLevel: 0,
-            maximumLevel: 18
+            maximumLevel: 18,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Dark Matter without labels',
         tooltip: 'CartoDB Dark Matter without labels basemap',
         iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/dark_nolabels/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://{s}.basemaps.cartocdn.com/rastertiles/dark_nolabels/{z}/{x}/{y}.png',
             credit: CartoAttribution,
             minimumLevel: 0,
-            maximumLevel: 18
+            maximumLevel: 18,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Voyager',
         tooltip: 'CartoDB Voyager basemap',
         iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/voyager_labels_under/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}.png',
             credit: CartoAttribution,
             minimumLevel: 0,
-            maximumLevel: 18
+            maximumLevel: 18,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Voyager without labels',
         tooltip: 'CartoDB Voyager without labels basemap',
         iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/voyager_nolabels/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png',
             credit: CartoAttribution,
             minimumLevel: 0,
-            maximumLevel: 18
+            maximumLevel: 18,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'National Map Satellite',
         iconUrl: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/4/6/4',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
             credit: 'Tile data from <a href="https://basemap.nationalmap.gov/">USGS</a>',
             minimumLevel: 0,
-            maximumLevel: 16
+            maximumLevel: 16,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Stamen Terrain',
         iconUrl: 'https://stamen-tiles-a.a.ssl.fastly.net/terrain/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
             credit: StamenAttribution,
             subdomains: 'abcd',
             minimumLevel: 0,
-            maximumLevel: 14
+            maximumLevel: 14,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Stamen Terrain Background',
         iconUrl: 'https://stamen-tiles-a.a.ssl.fastly.net/terrain-background/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain-background/{z}/{x}/{y}.png',
             credit: StamenAttribution,
             subdomains: 'abcd',
             minimumLevel: 0,
-            maximumLevel: 14
+            maximumLevel: 14,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Stamen Toner',
         iconUrl: 'https://stamen-tiles-a.a.ssl.fastly.net/toner/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
             credit: StamenAttribution,
             subdomains: 'abcd',
             minimumLevel: 0,
-            maximumLevel: 14
+            maximumLevel: 14,
           });
-        }
+        },
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Stamen Toner Lite',
         iconUrl: 'https://stamen-tiles-a.a.ssl.fastly.net/toner-lite/5/15/12.png',
-        creationFunction: function() {
+        creationFunction() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
             credit: StamenAttribution,
             subdomains: 'abcd',
             minimumLevel: 0,
-            maximumLevel: 14
+            maximumLevel: 14,
           });
-        }
+        },
       }));
 
       // Initialize the viewer - this works without a token
@@ -203,7 +202,7 @@ export default defineComponent({
         selectionIndicator: false,
       });
       // Remove the Terrain section of the baseLayerPicker
-      cesiumViewer.value.baseLayerPicker.viewModel.terrainProviderViewModels.removeAll()
+      cesiumViewer.value.baseLayerPicker.viewModel.terrainProviderViewModels.removeAll();
 
       cesiumViewer.value.forceResize();
       cesiumViewer.value.camera.flyTo({

--- a/src/components/organisms/CesiumViewer.vue
+++ b/src/components/organisms/CesiumViewer.vue
@@ -21,26 +21,170 @@ export default defineComponent({
       // Create ProviderViewModel based on different imagery sources
       // - these can be used without Cesium Ion
       var imageryViewModels = [];
+      /* Stamen's website (http://maps.stamen.com) as of 2019-08-28 says that the
+       * maps they host may be used free of charge.  For http access, use a url like
+       * http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png */
+      let StamenAttribution = 'Map tiles by <a href="http://stamen.com">Stamen ' +
+        'Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">' +
+        'CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap' +
+        '</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.';
+
+      /* Per Carto's website regarding basemap attribution: https://carto.com/help/working-with-data/attribution/#basemaps */
+      let CartoAttribution = 'Map tiles by <a href="https://carto.com">Carto</a>, under CC BY 3.0. Data by <a href="https://www.openstreetmap.org/">OpenStreetMap</a>, under ODbL.'
+
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Open\u00adStreet\u00adMap',
         iconUrl: Cesium.buildModuleUrl('Widgets/Images/ImageryProviders/openStreetMap.png'),
         tooltip: 'OpenStreetMap (OSM) is a collaborative project to create a free editable \
       map of the world.\nhttp://www.openstreetmap.org',
         creationFunction: function() {
-          return new Cesium.OpenStreetMapImageryProvider({
-            url: 'https://a.tile.openstreetmap.org/'
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            subdomains: 'abc',
+            minimumLevel: 0,
+            maximumLevel: 19
           });
         }
       }));
       imageryViewModels.push(new Cesium.ProviderViewModel({
         name: 'Positron',
         tooltip: 'CartoDB Positron basemap',
-        // iconUrl: Cesium.buildModuleUrl(),
+        iconUrl: 'http://a.basemaps.cartocdn.com/light_all/5/15/12.png',
         creationFunction: function() {
           return new Cesium.UrlTemplateImageryProvider({
             url: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-            iconUrl: 'http://a.basemaps.cartocdn.com/light_all/5/15/12.png',
-            credit: 'Map tiles by CartoDB, under CC BY 3.0. Data by OpenStreetMap, under ODbL.'
+            credit: CartoAttribution,
+            minimumLevel: 0,
+            maximumLevel: 18
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Positron without labels',
+        tooltip: 'CartoDB Positron without labels basemap',
+        iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/light_nolabels/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://{s}.basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}.png',
+            credit: CartoAttribution,
+            minimumLevel: 0,
+            maximumLevel: 18
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Dark Matter',
+        tooltip: 'CartoDB Dark Matter basemap',
+        iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/dark_all/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://{s}.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png',
+            credit: CartoAttribution,
+            minimumLevel: 0,
+            maximumLevel: 18
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Dark Matter without labels',
+        tooltip: 'CartoDB Dark Matter without labels basemap',
+        iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/dark_nolabels/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://{s}.basemaps.cartocdn.com/rastertiles/dark_nolabels/{z}/{x}/{y}.png',
+            credit: CartoAttribution,
+            minimumLevel: 0,
+            maximumLevel: 18
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Voyager',
+        tooltip: 'CartoDB Voyager basemap',
+        iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/voyager_labels_under/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}.png',
+            credit: CartoAttribution,
+            minimumLevel: 0,
+            maximumLevel: 18
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Voyager without labels',
+        tooltip: 'CartoDB Voyager without labels basemap',
+        iconUrl: 'http://a.basemaps.cartocdn.com/rastertiles/voyager_nolabels/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png',
+            credit: CartoAttribution,
+            minimumLevel: 0,
+            maximumLevel: 18
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'National Map Satellite',
+        iconUrl: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/4/6/4',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
+            credit: 'Tile data from <a href="https://basemap.nationalmap.gov/">USGS</a>',
+            minimumLevel: 0,
+            maximumLevel: 16
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Stamen Terrain',
+        iconUrl: 'https://stamen-tiles-a.a.ssl.fastly.net/terrain/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+            credit: StamenAttribution,
+            subdomains: 'abcd',
+            minimumLevel: 0,
+            maximumLevel: 14
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Stamen Terrain Background',
+        iconUrl: 'https://stamen-tiles-a.a.ssl.fastly.net/terrain-background/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain-background/{z}/{x}/{y}.png',
+            credit: StamenAttribution,
+            subdomains: 'abcd',
+            minimumLevel: 0,
+            maximumLevel: 14
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Stamen Toner',
+        iconUrl: 'https://stamen-tiles-a.a.ssl.fastly.net/toner/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+            credit: StamenAttribution,
+            subdomains: 'abcd',
+            minimumLevel: 0,
+            maximumLevel: 14
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Stamen Toner Lite',
+        iconUrl: 'https://stamen-tiles-a.a.ssl.fastly.net/toner-lite/5/15/12.png',
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+            credit: StamenAttribution,
+            subdomains: 'abcd',
+            minimumLevel: 0,
+            maximumLevel: 14
           });
         }
       }));

--- a/src/components/organisms/CesiumViewer.vue
+++ b/src/components/organisms/CesiumViewer.vue
@@ -220,8 +220,8 @@ export default defineComponent({
           const point = cesiumViewer.value.entities.add({
             position: worldPosition,
             point: {
-              color: Cesium.Color.WHITE,
-              pixelSize: 5,
+              color: Cesium.Color.GREY,
+              pixelSize: 10,
               heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
             },
           });
@@ -293,7 +293,7 @@ export default defineComponent({
           geoShape.value.type = 'Polygon';
           geoShape.value.coordinates = polyPoints;
           terminateShape();
-        }, Cesium.ScreenSpaceEventType.RIGHT_CLICK);
+        }, Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
       }
     });
     const getFootPrints = async () => {

--- a/src/components/organisms/CesiumViewer.vue
+++ b/src/components/organisms/CesiumViewer.vue
@@ -18,15 +18,49 @@ export default defineComponent({
 
     const cesiumViewer = ref();
     onMounted(() => {
+      // Create ProviderViewModel based on different imagery sources
+      // - these can be used without Cesium Ion
+      var imageryViewModels = [];
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Open\u00adStreet\u00adMap',
+        iconUrl: Cesium.buildModuleUrl('Widgets/Images/ImageryProviders/openStreetMap.png'),
+        tooltip: 'OpenStreetMap (OSM) is a collaborative project to create a free editable \
+      map of the world.\nhttp://www.openstreetmap.org',
+        creationFunction: function() {
+          return new Cesium.OpenStreetMapImageryProvider({
+            url: 'https://a.tile.openstreetmap.org/'
+          });
+        }
+      }));
+      imageryViewModels.push(new Cesium.ProviderViewModel({
+        name: 'Positron',
+        tooltip: 'CartoDB Positron basemap',
+        // iconUrl: Cesium.buildModuleUrl(),
+        creationFunction: function() {
+          return new Cesium.UrlTemplateImageryProvider({
+            url: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+            iconUrl: 'http://a.basemaps.cartocdn.com/light_all/5/15/12.png',
+            credit: 'Map tiles by CartoDB, under CC BY 3.0. Data by OpenStreetMap, under ODbL.'
+          });
+        }
+      }));
+
+      // Initialize the viewer - this works without a token
       cesiumViewer.value = new Cesium.Viewer('cesiumContainer', {
+        imageryProvider: false,
+        imageryProviderViewModels: imageryViewModels,
+        selectedImageryProviderViewModel: imageryViewModels[0],
+        mapProjection: new Cesium.WebMercatorProjection(),
         animation: false,
         timeline: false,
-        fullscreenButton: false,
         infoBox: false,
-        selectionIndicator: false,
         homeButton: false,
-        terrainProvider: Cesium.createWorldTerrain(),
+        fullscreenButton: false,
+        selectionIndicator: false,
       });
+      // Remove the Terrain section of the baseLayerPicker
+      viewer.baseLayerPicker.viewModel.terrainProviderViewModels.removeAll()
+
       cesiumViewer.value.forceResize();
       cesiumViewer.value.camera.flyTo({
         destination: Cesium.Cartesian3.fromDegrees(-93.849688, 40.690265, 4000000),

--- a/src/components/organisms/CesiumViewer.vue
+++ b/src/components/organisms/CesiumViewer.vue
@@ -34,7 +34,7 @@ export default defineComponent({
       let CartoAttribution = 'Map tiles by <a href="https://carto.com">Carto</a>, under CC BY 3.0. Data by <a href="https://www.openstreetmap.org/">OpenStreetMap</a>, under ODbL.'
 
       imageryViewModels.push(new Cesium.ProviderViewModel({
-        name: 'Open\u00adStreet\u00adMap',
+        name: 'OpenStreetMap',
         iconUrl: Cesium.buildModuleUrl('Widgets/Images/ImageryProviders/openStreetMap.png'),
         tooltip: 'OpenStreetMap (OSM) is a collaborative project to create a free editable \
       map of the world.\nhttp://www.openstreetmap.org',

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/vue';
 import Vue from 'vue';
 import '@/plugins/composition';
 // import DatetimePicker from 'vuetify-datetime-picker';
-import Cesium from './plugins/cesium';
 import App from './App.vue';
 import router from './router';
 import vuetify from './plugins/vuetify';
@@ -10,7 +9,6 @@ import { restoreLogin, oauthClient, axiosInstance } from './api/rest';
 
 // Vue.use(DatetimePicker);
 
-Cesium.Ion.defaultAccessToken = process.env.VUE_APP_CESIUM_ACCESS_TOKEN;
 
 Sentry.init({
   Vue,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,16 @@ import * as Sentry from '@sentry/vue';
 import Vue from 'vue';
 import '@/plugins/composition';
 // import DatetimePicker from 'vuetify-datetime-picker';
+import Cesium from './plugins/cesium';
 import App from './App.vue';
 import router from './router';
 import vuetify from './plugins/vuetify';
 import { restoreLogin, oauthClient, axiosInstance } from './api/rest';
 
 // Vue.use(DatetimePicker);
+
+// Set token to `null` to avoid warning
+Cesium.Ion.defaultAccessToken = process.env.VUE_APP_CESIUM_ACCESS_TOKEN;
 
 
 Sentry.init({

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ import { restoreLogin, oauthClient, axiosInstance } from './api/rest';
 // Set token to `null` to avoid warning
 Cesium.Ion.defaultAccessToken = process.env.VUE_APP_CESIUM_ACCESS_TOKEN;
 
-
 Sentry.init({
   Vue,
   dsn: process.env.VUE_APP_SENTRY_DSN,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,9 +2274,9 @@ caseless@~0.12.0:
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 cesium@^1.85.0:
-  version "1.85.0"
-  resolved "https://registry.yarnpkg.com/cesium/-/cesium-1.85.0.tgz#00d983648710f13a925c20504548879eac38e902"
-  integrity sha512-GqcEkcG5owC7rDroZzy3ic9d5oCrpqmpLZ9kWVnVBgvtjL/aAS+eUZ2wz8vCYAcYW77wYnIWeBRbMbaqdAH2XQ==
+  version "1.87.1"
+  resolved "https://registry.yarnpkg.com/cesium/-/cesium-1.87.1.tgz#c122f8b92b2a1c01ad7feddb159531695b3a67a4"
+  integrity sha512-j0ywezLnCRJ3BWTnD7N2W2jfGlaLa5UklXpxVOLTZUx1NJsvkekpztHuRf4eMVCew/rKcXRzIOAvS7FHo6JHSw==
 
 chalk@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Resolve #16 

@marySalvi, note the base branch

This did require bumping the CesiumJS version

I added all of the same basemaps that we've been using from GeoJS. Here is a preview:

![Screen Shot 2021-11-23 at 4 59 34 PM](https://user-images.githubusercontent.com/22067021/143147395-039eb09d-cac4-4a16-82e2-1249ad8b3c5d.png)


https://user-images.githubusercontent.com/22067021/143147478-0a0731dc-a61f-4456-9483-8582ea95ed68.mov


-----

I also edited the search polygon tool to end on a double left click instead of a right-click to be consistent with GeoJS in the old viewer. And I changed the colors:

![Screen Shot 2021-11-23 at 5 02 24 PM](https://user-images.githubusercontent.com/22067021/143147578-07c17c76-4b6b-40ed-ba2e-c6de118eabd4.png)


